### PR TITLE
fix: use copy instead of mv

### DIFF
--- a/dist/setup.js
+++ b/dist/setup.js
@@ -5,7 +5,7 @@ import * as action from "@actions/core";
 import { downloadTool, extractZip } from "@actions/tool-cache";
 import * as cache from "@actions/cache";
 import { restoreCache, saveCache } from "@actions/cache";
-import { cp, rmRF } from "@actions/io";
+import { cp, mkdirP, rmRF } from "@actions/io";
 import { getExecOutput } from "@actions/exec";
 export default async (options) => {
     const { url, cacheKey } = getDownloadUrl(options);
@@ -33,6 +33,7 @@ export default async (options) => {
         const zipPath = await downloadTool(url);
         const extractedPath = await extractZip(zipPath);
         const exePath = await extractBun(extractedPath);
+        await mkdirP(dir);
         await cp(exePath, path);
         await rmRF(exePath);
         version = await verifyBun(path);

--- a/dist/setup.js
+++ b/dist/setup.js
@@ -5,7 +5,7 @@ import * as action from "@actions/core";
 import { downloadTool, extractZip } from "@actions/tool-cache";
 import * as cache from "@actions/cache";
 import { restoreCache, saveCache } from "@actions/cache";
-import { mv } from "@actions/io";
+import { cp, rmRF } from "@actions/io";
 import { getExecOutput } from "@actions/exec";
 export default async (options) => {
     const { url, cacheKey } = getDownloadUrl(options);
@@ -33,7 +33,8 @@ export default async (options) => {
         const zipPath = await downloadTool(url);
         const extractedPath = await extractZip(zipPath);
         const exePath = await extractBun(extractedPath);
-        await mv(exePath, path);
+        await cp(exePath, path);
+        await rmRF(exePath);
         version = await verifyBun(path);
     }
     if (!version) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -5,7 +5,7 @@ import * as action from "@actions/core";
 import { downloadTool, extractZip } from "@actions/tool-cache";
 import * as cache from "@actions/cache";
 import { restoreCache, saveCache } from "@actions/cache";
-import { mv } from "@actions/io";
+import { cp, rmRF } from "@actions/io";
 import { getExecOutput } from "@actions/exec";
 
 export default async (options?: {
@@ -41,7 +41,8 @@ export default async (options?: {
     const zipPath = await downloadTool(url);
     const extractedPath = await extractZip(zipPath);
     const exePath = await extractBun(extractedPath);
-    await mv(exePath, path);
+    await cp(exePath, path);
+    await rmRF(exePath);
     version = await verifyBun(path);
   }
   if (!version) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -5,7 +5,7 @@ import * as action from "@actions/core";
 import { downloadTool, extractZip } from "@actions/tool-cache";
 import * as cache from "@actions/cache";
 import { restoreCache, saveCache } from "@actions/cache";
-import { cp, rmRF } from "@actions/io";
+import { cp, mkdirP, rmRF } from "@actions/io";
 import { getExecOutput } from "@actions/exec";
 
 export default async (options?: {
@@ -41,6 +41,7 @@ export default async (options?: {
     const zipPath = await downloadTool(url);
     const extractedPath = await extractZip(zipPath);
     const exePath = await extractBun(extractedPath);
+    await mkdirP(dir);
     await cp(exePath, path);
     await rmRF(exePath);
     version = await verifyBun(path);


### PR DESCRIPTION
Hi,
mv fails on self-hosted runner with cache on different partitions, so this pr uses copy and remove approach same as [setup-kube](https://github.com/medyagh/setup-minikube/pull/125) 