### PR TITLE
build: bump nodejs to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ outputs:
   cache-hit:
     description: If the version of Bun was cached.
 runs:
-  using: node16
+  using: node20
   main: dist/action.js


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/