### PR TITLE
fix: save only when the cache is not hit

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -59,7 +59,7 @@ export default async (options?: {
       "Downloaded a new version of Bun, but failed to check its version? Try again in debug mode."
     );
   }
-  if (cacheEnabled) {
+  if (cacheEnabled && !cacheHit) {
     try {
       await saveCache([path], cacheKey);
     } catch (error) {


### PR DESCRIPTION
Found a warning when using the action:

`Failed to save: Unable to reserve cache with key bun-1.0.4-linux-x64-true-false, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/master, Key: bun-1.0.4-linux-x64-true-false, Version: 4793076103aa823b0a4c97942d7385d4346f77a3c30a0bad6e0f1d748becbab5`

So should we save the cache only when it's not hit?