### PR TITLE
docs: add --frozen-lockfile to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you need to authenticate with a private registry, you can set the `BUN_AUTH_T
 - name: Install Dependencies
   env:
     BUN_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  run: bun install
+  run: bun install --frozen-lockfile
 ```
 
 ### Node.js not needed


### PR DESCRIPTION
Many folks will copy/paste the sample code from the README directly. In CI, most people will want to enforce a frozen lockfile.