### PR TITLE
Add GitHub action to auto-update the v1 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release new action version
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: 'Tag name that the major tag will point to'
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+
+jobs:
+  update_tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/publish-action@v0.3.0
+        with:
+          source-tag: ${{ env.TAG_NAME }}


### PR DESCRIPTION
using https://github.com/actions/publish-action

see https://github.com/oven-sh/setup-bun/issues/50#issuecomment-1910733161

see https://github.com/actions/publish-action/blob/main/.github/workflows/release-new-action-version.yml for an example

closes #50