### PR TITLE
Make bun resolve to given file path when an absolute path is given

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,9 @@ jobs:
             run: |
               echo "$(jq '. += {"packageManager": "bun@1.1.0"}' package.json)" > package.json
           - name: /foo/package.json (bun@1.1.0)
-            file: ${{ github.workspace }}/foo//foo/package.json
+            file: /foo/package.json
             run: |
-              echo "$(jq '. += {"packageManager": "bun@1.1.0"}' package.json)" > ${{ github.workspace }}/foo/package.json
+              echo "$(jq '. += {"packageManager": "bun@1.1.0"}' package.json)" > /foo/package.json
           - name: package.json (yarn@bun@1.1.0)
             file: package.json
             run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,10 @@ jobs:
             file: package.json
             run: |
               echo "$(jq '. += {"packageManager": "bun@1.1.0"}' package.json)" > package.json
+          - name: /foo/package.json (bun@1.1.0)
+            file: ${{ github.workspace }}/foo//foo/package.json
+            run: |
+              echo "$(jq '. += {"packageManager": "bun@1.1.0"}' package.json)" > ${{ github.workspace }}/foo/package.json
           - name: package.json (yarn@bun@1.1.0)
             file: package.json
             run: |

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { debug, warning } from "@actions/core";
 import { info } from "node:console";
 import { existsSync, readFileSync, renameSync } from "node:fs";
-import { join, basename } from "node:path";
+import { resolve, basename } from "node:path";
 
 export function retry<T>(
   fn: () => Promise<T>,
@@ -48,7 +48,7 @@ export function readVersionFromFile(file: string): string | undefined {
 
   debug(`Reading version from ${file}`);
 
-  const path = join(cwd, file);
+  const path = resolve(cwd, file);
   const base = basename(file);
 
   if (!existsSync(path)) {


### PR DESCRIPTION
Sometimes we want the bun version to resolve to a `package.json` (or other) that is not in the default `GITHUB_WORKSPACE` directory and to do that we can allow to pass an absolute path as the `file` param which would then ignore the  `GITHUB_WORKSPACE` path.