### PR TITLE
fix: allow setting token for default registry

### DIFF
--- a/src/bunfig.ts
+++ b/src/bunfig.ts
@@ -31,7 +31,7 @@ export function createBunfig(options: BunfigOptions): string | null {
   }
 
   if (url && !owner) {
-    return `[install]${EOL}registry = "${url}"${EOL}`;
+    return `[install]${EOL}registry = { token = "$BUN_AUTH_TOKEN", url = "${url}"}${EOL}`;
   }
 
   return null;


### PR DESCRIPTION
Currently, you're only allowed to pass a token if you use a single private registry with a scope.

Our org uses multiple private registries, and has its own custom npm proxy which we apply as a default registry for all packages, but it needs auth.

This pr allows the user to set `BUN_AUTH_TOKEN` when configuring `registry-url` without a scope.