### PR TITLE
fix: default token only on public github instance

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ inputs:
   token:
     required: false
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
-    description: Personal access token (PAT) used to fetch tags from oven-sh/bun repository. Recommended for resolving wildcard/range versions to avoid GitHub API rate limiting.
+    description: Personal access token (PAT) used to fetch tags from oven-sh/bun repository. Recommended for resolving wildcard/range versions to avoid GitHub API rate limiting. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
 
 outputs:
   bun-version:


### PR DESCRIPTION
Fixes https://github.com/oven-sh/setup-bun/issues/156