### PR TITLE
ci: use `actions/checkout@v6.0.2` in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     permissions: write-all
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🗑️ Remove cache
         run: gh cache delete --all || true
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Bun
         uses: ./
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🛠️ Setup Bun
         uses: ./
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 📄 Setup file
         run: ${{ matrix.file.run }}
@@ -196,7 +196,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 📄 Setup file
         run: ${{ matrix.file.run }}
@@ -226,7 +226,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🛠️ Setup Bun
         uses: ./
@@ -251,7 +251,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🛠️ Setup Bun
         uses: ./


### PR DESCRIPTION
Use a version that supports Node 24.

`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`

Version 5 was the first to add support.

For #172 
