### PR TITLE
ci: update actions for the `autofix.ci` workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 🛠️ Setup Bun
         uses: ./
@@ -29,4 +29,4 @@ jobs:
           bun run build
 
       - name: 💾 Commit
-        uses: autofix-ci/action@551dded8c6cc8a1054039c8bc0b8b48c51dfc6ef
+        uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2


### PR DESCRIPTION
I used `v1.3.2` to avoid the hostname change.

https://github.com/autofix-ci/action/releases/tag/v1.3.3

https://github.com/autofix-ci/action/releases/tag/v1.3.2

Node 24 isn't being used by this action yet.

https://github.com/autofix-ci/action/blob/7a166d7532b277f34e16238930461bf77f9d7ed8/action.yml#L7

For #172 
