### PR TITLE
ci: update actions for the `Release new action version` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/publish-action@f784495ce78a41bac4ed7e34a73f0034015764bb # v0.3.0
+      - uses: actions/publish-action@23f4c6f12633a2da8f44938b71fde9afec138fb4 # v0.4.0
         env:
           TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
         with:


### PR DESCRIPTION
Update the used actions to versions that support Node 24.

For #172 
